### PR TITLE
Prevent skipped overlays when face coordinates are zero

### DIFF
--- a/app.js
+++ b/app.js
@@ -67,7 +67,8 @@ function drawFrame(glassesImg, eyeCenterX, eyeCenterY, glassesWidth, glassesHeig
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     
     // Only draw if we have valid positions and a glasses image
-    if (glassesImg && eyeCenterX && eyeCenterY && glassesWidth && glassesHeight) {
+    // Using explicit nullish checks so coordinates at 0 don't skip drawing
+    if (glassesImg && eyeCenterX != null && eyeCenterY != null && glassesWidth && glassesHeight) {
         ctx.save();
         ctx.translate(eyeCenterX, eyeCenterY);
         ctx.rotate(angle || 0);


### PR DESCRIPTION
## Summary
- handle zero coordinate values when drawing glasses overlay

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6895882ac4ec832c9ea6a0768206c212