### PR TITLE
Add Jest tests for core drawing utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "glasses-photobooth",
+  "version": "1.0.0",
+  "description": "Aplikasi ini memungkinkan pengguna untuk mencoba berbagai model kacamata secara virtual menggunakan webcam. Aplikasi ini memanfaatkan teknologi deteksi wajah untuk menempatkan kacamata dengan tepat pada wajah pengguna dalam waktu nyata (real-time).",
+  "main": "app.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,0 +1,31 @@
+const { getCenterOfPoints, drawFrame } = require('../app');
+
+describe('getCenterOfPoints', () => {
+  test('averages multiple points', () => {
+    const points = [{ x: 0, y: 0 }, { x: 2, y: 2 }];
+    expect(getCenterOfPoints(points)).toEqual({ x: 1, y: 1 });
+  });
+
+  test('handles single point', () => {
+    const points = [{ x: 5, y: 7 }];
+    expect(getCenterOfPoints(points)).toEqual({ x: 5, y: 7 });
+  });
+});
+
+describe('drawFrame', () => {
+  test('draws when coordinates are zero', () => {
+    global.canvas = { width: 100, height: 100 };
+    const mockCtx = {
+      clearRect: jest.fn(),
+      save: jest.fn(),
+      translate: jest.fn(),
+      rotate: jest.fn(),
+      drawImage: jest.fn(),
+      restore: jest.fn(),
+    };
+    global.ctx = mockCtx;
+    const img = {};
+    drawFrame(img, 0, 0, 10, 10, 0);
+    expect(mockCtx.drawImage).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- export utility functions and guard browser-only code for Node-based tests
- add Jest test suite for getCenterOfPoints and drawFrame functions
- set up Jest config in package.json and ignore node modules

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689589340ddc832c99ee67b6fb4431af